### PR TITLE
[change]edit 1password_article tag

### DIFF
--- a/articles/652aa1302caa76.md
+++ b/articles/652aa1302caa76.md
@@ -2,7 +2,7 @@
 title: "1Passwordで2FAの共有ができる件"
 emoji: "🔑"
 type: "tech" # tech: 技術記事 / idea: アイデア
-topics: ["1Password","2要素認証","2段階認証"]
+topics: ["1Password","2FA"]
 published: true
 ---
 


### PR DESCRIPTION
# ブログタイトル
1Passwordで2FAの共有ができる件

# 変更理由
tagを"2FA"にした方が他の記事との関連性上良さそうなので修正
